### PR TITLE
Fix Calendar Styling

### DIFF
--- a/Adara-Dark/cinnamon/cinnamon.css
+++ b/Adara-Dark/cinnamon/cinnamon.css
@@ -149,9 +149,7 @@ StEntry StIcon,
   icon-size: 16px;
 }
 
-StEntry:focus > StIcon,
-StEntry:active > StIcon,
-StEntry:pressed > StIcon,
+StEntry:focus > StIcon, StEntry:active > StIcon, StEntry:pressed > StIcon,
 .menu StEntry:focus > StIcon,
 .menu StEntry:active > StIcon,
 .menu StEntry:pressed > StIcon,
@@ -858,7 +856,6 @@ StEntry:pressed > StIcon,
 
 .calendar-nonwork-day {
   color: rgba(255, 255, 255, 0.75);
-  background-color: #090909;
   border-color: rgba(0, 0, 0, 0.35);
 }
 
@@ -874,6 +871,167 @@ StEntry:pressed > StIcon,
 
 .calendar-week-number {
   color: rgba(255, 255, 255, 0.75);
+}
+
+.calendar-today-day-label {
+  color: rgba(255, 255, 255, 0.95);
+  font-weight: bold;
+  font-size: 150%;
+  text-align: center;
+}
+
+.calendar-today-date-label {
+  color: rgba(255, 255, 255, 0.75);
+  font-weight: bold;
+  font-size: 120%;
+  text-align: center;
+}
+
+.calendar-not-today {
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.calendar-not-today:selected {
+  font-weight: bold;
+  background-color: #090909;
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.calendar-not-today:selected:hover {
+  font-weight: bold;
+  color: rgba(255, 255, 255, 0.95);
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+/* Event Box */
+.calendar-events-main-box {
+  height: 300px;
+  margin-right: .5em;
+  padding: .5em;
+  min-width: 350px;
+  border: 1px solid rgba(0, 0, 0, 0.45);
+  background-color: #090909;
+}
+
+.calendar-events-no-events-button {
+  margin: 6px 0 6px 0;
+  padding: 6px;
+}
+
+.calendar-events-no-events-button:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.calendar-events-no-events-button:hover .calendar-events-no-events-icon,
+.calendar-events-no-events-button:hover .calendar-events-no-events-label {
+  color: #999;
+}
+
+.calendar-events-no-events-icon,
+.calendar-events-no-events-label {
+  font-weight: bold;
+  color: #999;
+  text-align: center;
+}
+
+.calendar-events-date-label {
+  padding: .1em .1em .5em .1em;
+  color: rgba(255, 255, 255, 0.95);
+  font-weight: bold;
+  text-align: center;
+}
+
+.calendar-events-event-container {
+  padding: 0;
+}
+
+.calendar-event-button {
+  border: 1px solid rgba(0, 0, 0, 0.45);
+}
+
+.calendar-event-button .calendar-event-time-past {
+  color: rgba(255, 255, 255, 0.95);
+  font-weight: bold;
+  text-align: left;
+  margin-bottom: .2em;
+}
+
+.calendar-event-button .calendar-event-time-present {
+  color: rgba(255, 255, 255, 0.95);
+  font-weight: bold;
+  text-align: left;
+  margin-bottom: .2em;
+}
+
+.calendar-event-button .calendar-event-time-present:all-day {
+  color: rgba(255, 255, 255, 0.1);
+}
+
+.calendar-event-button .calendar-event-time-future {
+  color: rgba(255, 255, 255, 0.95);
+  font-weight: bold;
+  text-align: left;
+  margin-bottom: .2em;
+}
+
+.calendar-event-button .calendar-event-summary {
+  color: rgba(255, 255, 255, 0.95);
+  text-align: left;
+  width: 200px;
+}
+
+.calendar-event-button .calendar-event-countdown {
+  text-align: right;
+  margin-bottom: .6em;
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.calendar-event-button .calendar-event-countdown:soon {
+  font-weight: bold;
+}
+
+.calendar-event-button .calendar-event-countdown:imminent {
+  font-weight: bold;
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.calendar-event-button .calendar-event-countdown:current {
+  font-weight: bold;
+  color: rgba(255, 255, 255, 0.1);
+}
+
+.calendar-event-button:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(0, 0, 0, 0.35);
+}
+
+.calendar-event-button:hover .calendar-event-time-past,
+.calendar-event-button:hover .calendar-event-time-present,
+.calendar-event-button:hover .calendar-event-time-future,
+.calendar-event-button:hover .calendar-event-summary {
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.calendar-event-button:hover .calendar-event-countdown {
+  text-align: right;
+  margin-bottom: .6em;
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.calendar-event-button:hover .calendar-event-countdown:soon {
+  font-weight: bold;
+}
+
+.calendar-event-button:hover .calendar-event-countdown:imminent {
+  font-weight: bold;
+}
+
+.calendar-event-button:hover .calendar-event-countdown:current {
+  font-weight: bold;
+}
+
+.calendar-event-color-strip {
+  width: 2px;
 }
 
 /* ======================================
@@ -2412,9 +2570,7 @@ StEntry:pressed > StIcon,
   icon-size: 16px;
 }
 
-.menu .slingshot .entry:focus > StIcon,
-.menu .slingshot .entry:active > StIcon,
-.menu .slingshot .entry:pressed > StIcon {
+.menu .slingshot .entry:focus > StIcon, .menu .slingshot .entry:active > StIcon, .menu .slingshot .entry:pressed > StIcon {
   color: rgba(255, 255, 255, 0.95);
 }
 
@@ -2786,18 +2942,12 @@ StEntry:pressed > StIcon,
   font-size: 100%;
 }
 
-.panel-bottom .stopwatch-running, .panel-bottom
-.stopwatch-paused, .panel-bottom
-.stopwatch-ready:hover, .panel-bottom
-.stopwatch-paused:hover {
+.panel-bottom .stopwatch-running, .panel-bottom .stopwatch-paused, .panel-bottom .stopwatch-ready:hover, .panel-bottom .stopwatch-paused:hover {
   border-bottom: 1px;
   padding-top: 1px;
 }
 
-.panel-top .stopwatch-running, .panel-top
-.stopwatch-paused, .panel-top
-.stopwatch-ready:hover, .panel-top
-.stopwatch-paused:hover {
+.panel-top .stopwatch-running, .panel-top .stopwatch-paused, .panel-top .stopwatch-ready:hover, .panel-top .stopwatch-paused:hover {
   border-top: 1px;
   padding-bottom: 1px;
 }

--- a/Adara/cinnamon/cinnamon.css
+++ b/Adara/cinnamon/cinnamon.css
@@ -149,9 +149,7 @@ StEntry StIcon,
   icon-size: 16px;
 }
 
-StEntry:focus > StIcon,
-StEntry:active > StIcon,
-StEntry:pressed > StIcon,
+StEntry:focus > StIcon, StEntry:active > StIcon, StEntry:pressed > StIcon,
 .menu StEntry:focus > StIcon,
 .menu StEntry:active > StIcon,
 .menu StEntry:pressed > StIcon,
@@ -858,7 +856,6 @@ StEntry:pressed > StIcon,
 
 .calendar-nonwork-day {
   color: rgba(0, 0, 0, 0.6);
-  background-color: #f0f0f0;
   border-color: rgba(0, 0, 0, 0.15);
 }
 
@@ -874,6 +871,167 @@ StEntry:pressed > StIcon,
 
 .calendar-week-number {
   color: rgba(0, 0, 0, 0.6);
+}
+
+.calendar-today-day-label {
+  color: rgba(0, 0, 0, 0.7);
+  font-weight: bold;
+  font-size: 150%;
+  text-align: center;
+}
+
+.calendar-today-date-label {
+  color: rgba(0, 0, 0, 0.6);
+  font-weight: bold;
+  font-size: 120%;
+  text-align: center;
+}
+
+.calendar-not-today {
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.calendar-not-today:selected {
+  font-weight: bold;
+  background-color: #f0f0f0;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.calendar-not-today:selected:hover {
+  font-weight: bold;
+  color: rgba(0, 0, 0, 0.7);
+  background-color: rgba(0, 0, 0, 0.15);
+}
+
+/* Event Box */
+.calendar-events-main-box {
+  height: 300px;
+  margin-right: .5em;
+  padding: .5em;
+  min-width: 350px;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  background-color: #f0f0f0;
+}
+
+.calendar-events-no-events-button {
+  margin: 6px 0 6px 0;
+  padding: 6px;
+}
+
+.calendar-events-no-events-button:hover {
+  background-color: rgba(0, 0, 0, 0.15);
+}
+
+.calendar-events-no-events-button:hover .calendar-events-no-events-icon,
+.calendar-events-no-events-button:hover .calendar-events-no-events-label {
+  color: #444;
+}
+
+.calendar-events-no-events-icon,
+.calendar-events-no-events-label {
+  font-weight: bold;
+  color: #444;
+  text-align: center;
+}
+
+.calendar-events-date-label {
+  padding: .1em .1em .5em .1em;
+  color: rgba(0, 0, 0, 0.7);
+  font-weight: bold;
+  text-align: center;
+}
+
+.calendar-events-event-container {
+  padding: 0;
+}
+
+.calendar-event-button {
+  border: 1px solid rgba(0, 0, 0, 0.2);
+}
+
+.calendar-event-button .calendar-event-time-past {
+  color: rgba(0, 0, 0, 0.7);
+  font-weight: bold;
+  text-align: left;
+  margin-bottom: .2em;
+}
+
+.calendar-event-button .calendar-event-time-present {
+  color: rgba(0, 0, 0, 0.7);
+  font-weight: bold;
+  text-align: left;
+  margin-bottom: .2em;
+}
+
+.calendar-event-button .calendar-event-time-present:all-day {
+  color: rgba(0, 0, 0, 0.15);
+}
+
+.calendar-event-button .calendar-event-time-future {
+  color: rgba(0, 0, 0, 0.7);
+  font-weight: bold;
+  text-align: left;
+  margin-bottom: .2em;
+}
+
+.calendar-event-button .calendar-event-summary {
+  color: rgba(0, 0, 0, 0.7);
+  text-align: left;
+  width: 200px;
+}
+
+.calendar-event-button .calendar-event-countdown {
+  text-align: right;
+  margin-bottom: .6em;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.calendar-event-button .calendar-event-countdown:soon {
+  font-weight: bold;
+}
+
+.calendar-event-button .calendar-event-countdown:imminent {
+  font-weight: bold;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.calendar-event-button .calendar-event-countdown:current {
+  font-weight: bold;
+  color: rgba(0, 0, 0, 0.15);
+}
+
+.calendar-event-button:hover {
+  background-color: rgba(0, 0, 0, 0.15);
+  border: 1px solid rgba(0, 0, 0, 0.15);
+}
+
+.calendar-event-button:hover .calendar-event-time-past,
+.calendar-event-button:hover .calendar-event-time-present,
+.calendar-event-button:hover .calendar-event-time-future,
+.calendar-event-button:hover .calendar-event-summary {
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.calendar-event-button:hover .calendar-event-countdown {
+  text-align: right;
+  margin-bottom: .6em;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.calendar-event-button:hover .calendar-event-countdown:soon {
+  font-weight: bold;
+}
+
+.calendar-event-button:hover .calendar-event-countdown:imminent {
+  font-weight: bold;
+}
+
+.calendar-event-button:hover .calendar-event-countdown:current {
+  font-weight: bold;
+}
+
+.calendar-event-color-strip {
+  width: 2px;
 }
 
 /* ======================================
@@ -2412,9 +2570,7 @@ StEntry:pressed > StIcon,
   icon-size: 16px;
 }
 
-.menu .slingshot .entry:focus > StIcon,
-.menu .slingshot .entry:active > StIcon,
-.menu .slingshot .entry:pressed > StIcon {
+.menu .slingshot .entry:focus > StIcon, .menu .slingshot .entry:active > StIcon, .menu .slingshot .entry:pressed > StIcon {
   color: rgba(0, 0, 0, 0.7);
 }
 
@@ -2786,18 +2942,12 @@ StEntry:pressed > StIcon,
   font-size: 100%;
 }
 
-.panel-bottom .stopwatch-running, .panel-bottom
-.stopwatch-paused, .panel-bottom
-.stopwatch-ready:hover, .panel-bottom
-.stopwatch-paused:hover {
+.panel-bottom .stopwatch-running, .panel-bottom .stopwatch-paused, .panel-bottom .stopwatch-ready:hover, .panel-bottom .stopwatch-paused:hover {
   border-bottom: 1px;
   padding-top: 1px;
 }
 
-.panel-top .stopwatch-running, .panel-top
-.stopwatch-paused, .panel-top
-.stopwatch-ready:hover, .panel-top
-.stopwatch-paused:hover {
+.panel-top .stopwatch-running, .panel-top .stopwatch-paused, .panel-top .stopwatch-ready:hover, .panel-top .stopwatch-paused:hover {
   border-top: 1px;
   padding-bottom: 1px;
 }

--- a/Adara/cinnamon/scss/base/_options.scss
+++ b/Adara/cinnamon/scss/base/_options.scss
@@ -1,1 +1,1 @@
-$dark-mode: true;
+$dark-mode: false;

--- a/Adara/cinnamon/scss/base/_options.scss
+++ b/Adara/cinnamon/scss/base/_options.scss
@@ -1,1 +1,1 @@
-$dark-mode: false;
+$dark-mode: true;

--- a/Adara/cinnamon/scss/main/applets/_calendar.scss
+++ b/Adara/cinnamon/scss/main/applets/_calendar.scss
@@ -70,7 +70,6 @@
 }
 .calendar-nonwork-day {
 	color: $text-secondary;
-	background-color: $background-secondary;
 	border-color: $border-secondary;
 }
 
@@ -86,4 +85,165 @@
 
 .calendar-week-number {
 	color: $text-secondary;
+}
+
+.calendar-today-day-label {
+    color: $text-primary;
+    font-weight: bold;
+    font-size: 150%;
+    text-align: center;
+}
+
+.calendar-today-date-label {
+    color: $text-secondary;
+    font-weight: bold;
+    font-size: 120%;
+    text-align: center;
+}
+
+.calendar-not-today {
+  color: $text-primary; 
+}
+  
+.calendar-not-today:selected {
+    font-weight: bold;
+    background-color: $background-secondary;
+    color: $text-primary; 
+}
+    
+.calendar-not-today:selected:hover {
+      font-weight: bold;
+      color: $text-primary;
+      background-color: $background-hover; 
+}
+
+/* Event Box */
+.calendar-events-main-box {
+  height: 300px;
+  margin-right: .5em;
+  padding: .5em;
+  min-width: 350px;
+  border: 1px solid $border-primary;
+  background-color: $background-secondary; 
+}
+
+.calendar-events-no-events-button {
+  margin: 6px 0 6px 0;
+  padding: 6px; 
+}
+  
+.calendar-events-no-events-button:hover {
+    background-color: $background-hover; 
+}
+    
+.calendar-events-no-events-button:hover .calendar-events-no-events-icon,
+.calendar-events-no-events-button:hover .calendar-events-no-events-label {
+      color: $accent-primary; 
+}
+
+.calendar-events-no-events-icon,
+.calendar-events-no-events-label {
+  font-weight: bold;
+  color: $accent-primary;
+  text-align: center; 
+}
+
+.calendar-events-date-label {
+  padding: .1em .1em .5em .1em;
+  color: $text-primary;
+  font-weight: bold;
+  text-align: center; 
+}
+
+.calendar-events-event-container {
+  padding: 0; 
+}
+
+.calendar-event-button {
+  border: 1px solid $border-primary; 
+}
+
+.calendar-event-button .calendar-event-time-past {
+    color: $text-primary;
+    font-weight: bold;
+    text-align: left;
+    margin-bottom: .2em; 
+}
+  
+.calendar-event-button .calendar-event-time-present {
+    color: $text-primary;
+    font-weight: bold;
+    text-align: left;
+    margin-bottom: .2em; 
+}
+    
+.calendar-event-button .calendar-event-time-present:all-day {
+      color: $background-hover; 
+}
+  
+.calendar-event-button .calendar-event-time-future {
+    color: $text-primary;
+    font-weight: bold;
+    text-align: left;
+    margin-bottom: .2em; 
+}
+  
+.calendar-event-button .calendar-event-summary {
+    color: $text-primary;
+    text-align: left;
+    width: 200px; 
+}
+  
+.calendar-event-button .calendar-event-countdown {
+    text-align: right;
+    margin-bottom: .6em;
+    color: $text-primary; 
+}
+    
+.calendar-event-button .calendar-event-countdown:soon {
+      font-weight: bold; 
+}
+    
+.calendar-event-button .calendar-event-countdown:imminent {
+      font-weight: bold;
+      color: $text-primary; 
+}
+    
+.calendar-event-button .calendar-event-countdown:current {
+      font-weight: bold;
+      color: $background-hover; 
+}
+  
+.calendar-event-button:hover {
+    background-color: $background-hover;
+    border: 1px solid $border-secondary; 
+}
+
+.calendar-event-button:hover .calendar-event-time-past,
+.calendar-event-button:hover .calendar-event-time-present,
+.calendar-event-button:hover .calendar-event-time-future,
+.calendar-event-button:hover .calendar-event-summary {
+      color: $text-primary; 
+}
+    
+.calendar-event-button:hover .calendar-event-countdown {
+      text-align: right;
+      margin-bottom: .6em;
+      color: $text-primary; 
+}
+      
+.calendar-event-button:hover .calendar-event-countdown:soon {
+        font-weight: bold; 
+}
+      
+.calendar-event-button:hover .calendar-event-countdown:imminent {
+        font-weight: bold; 
+}
+      
+.calendar-event-button:hover .calendar-event-countdown:current {
+        font-weight: bold; 
+}
+
+.calendar-event-color-strip {
+  width: 2px; 
 }


### PR DESCRIPTION
On LMDE 5, using Cinnamon 5.2.7, the event portion of the calendar is left unstyled, defaulting back to the default Cinnamon theme. The aim of this pull request is to fix this issue, improving readability of calendar events as well as improving the look and feel. 

# What's Changed
- The non-work days background has been removed for better looks, as the background looked terrible on the light theme.
- The current day and date have been styled using correct text colors and font sizes.
- Selection of a day that is not the current day now has a background.
- The event box has been styled using the correct colors. 

# **Before**:
![before-d](https://user-images.githubusercontent.com/45970663/169929215-58cd4ce0-20e9-4824-ad6c-6e956eb8af7b.png)
![before-l](https://user-images.githubusercontent.com/45970663/169929216-4facae4a-68f6-4add-bba8-258ef3fed208.png)
# **After**:
![after-d](https://user-images.githubusercontent.com/45970663/169929238-494ffabf-3457-440a-99ad-122276fe478f.png)
![after-l](https://user-images.githubusercontent.com/45970663/169929239-d36a8782-1d30-45c3-8f8f-2311161208f1.png)
 
# Testing
I have successfully installed the theme, with the changes, on LMDE 5 using Cinnamon 5.2.7. The sassc version is below.
```
sassc: [NA]
libsass: 3.6.4+20201122
sass2scss: 1.1.1
sass: 3.5
```

I hope you consider this pull request. Please let me know if there is anything that needs to be changed.