### PR TITLE
Fixes for current Cinnamon

### DIFF
--- a/Adara-Dark/cinnamon/cinnamon.css
+++ b/Adara-Dark/cinnamon/cinnamon.css
@@ -149,9 +149,7 @@ StEntry StIcon,
   icon-size: 16px;
 }
 
-StEntry:focus > StIcon,
-StEntry:active > StIcon,
-StEntry:pressed > StIcon,
+StEntry:focus > StIcon, StEntry:active > StIcon, StEntry:pressed > StIcon,
 .menu StEntry:focus > StIcon,
 .menu StEntry:active > StIcon,
 .menu StEntry:pressed > StIcon,
@@ -958,6 +956,12 @@ StEntry:pressed > StIcon,
  * ! Grouped window list
  * ====================================== */
 .grouped-window-list-thumbnail-menu {
+  border-radius: 3px;
+  color: rgba(255, 255, 255, 0.95);
+  border: 1px solid rgba(0, 0, 0, 0.45);
+  background-color: #111111;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+  padding: 3px;
   spacing: 3px;
 }
 
@@ -992,7 +996,7 @@ StEntry:pressed > StIcon,
 }
 
 .grouped-window-list-button-label {
-  padding: 0;
+  padding: 0 6px;
 }
 
 .grouped-window-list-item-box {
@@ -2026,12 +2030,12 @@ StEntry:pressed > StIcon,
  *
  * See also window-list module for a similar selector
  */
-#uiGroup > #altTabPopup {
+#altTabPopup {
   padding: 0;
   spacing: 6px;
 }
 
-#uiGroup > #altTabPopup .switcher-list {
+#altTabPopup .switcher-list {
   border-radius: 3px;
   color: rgba(255, 255, 255, 0.95);
   border: 1px solid rgba(0, 0, 0, 0.45);
@@ -2042,28 +2046,34 @@ StEntry:pressed > StIcon,
   padding: 3px;
 }
 
-#uiGroup > #altTabPopup .switcher-list .item-box {
+#altTabPopup .switcher-list .item-box {
   padding: 6px;
 }
 
-#uiGroup > #altTabPopup .switcher-list .item-box:selected {
+#altTabPopup .switcher-list .item-box:selected {
   background-color: rgba(255, 255, 255, 0.1);
   border-radius: 3px;
   color: rgba(255, 255, 255, 0.95);
-  /* Popup thumbnail */
+  /*
+				 *  Popup thumbnail
+				 *      Commented this out because it also affects the last item in the window selection,
+				 *      not showing it as highlighted. The popup thumbnails are currently darkened
+				 *      like the selected item in the window selection, this should probably be fixed
+				 */
+  /*
+				&:last-child {
+					padding: $padding-xs;
+					background: none;
+					color: $text-primary;
+				}
+				*/
 }
 
-#uiGroup > #altTabPopup .switcher-list .item-box:selected:last-child {
-  padding: 6px;
-  background: none;
-  color: rgba(255, 255, 255, 0.95);
-}
-
-#uiGroup > #altTabPopup .switcher-arrow {
+#altTabPopup .switcher-arrow {
   color: transparent;
 }
 
-#uiGroup > #altTabPopup .thumbnail {
+#altTabPopup .thumbnail {
   width: 256px;
 }
 
@@ -2071,7 +2081,7 @@ StEntry:pressed > StIcon,
  * This styles the window name box when alt-tab is
  * in 'coverflow' or 'timeline' modes
  */
-#uiGroup > StWidget > .switcher-list {
+StWidget > .switcher-list {
   border-radius: 3px;
   color: rgba(255, 255, 255, 0.95);
   border: 1px solid rgba(0, 0, 0, 0.45);
@@ -2412,9 +2422,7 @@ StEntry:pressed > StIcon,
   icon-size: 16px;
 }
 
-.menu .slingshot .entry:focus > StIcon,
-.menu .slingshot .entry:active > StIcon,
-.menu .slingshot .entry:pressed > StIcon {
+.menu .slingshot .entry:focus > StIcon, .menu .slingshot .entry:active > StIcon, .menu .slingshot .entry:pressed > StIcon {
   color: rgba(255, 255, 255, 0.95);
 }
 
@@ -2786,18 +2794,12 @@ StEntry:pressed > StIcon,
   font-size: 100%;
 }
 
-.panel-bottom .stopwatch-running, .panel-bottom
-.stopwatch-paused, .panel-bottom
-.stopwatch-ready:hover, .panel-bottom
-.stopwatch-paused:hover {
+.panel-bottom .stopwatch-running, .panel-bottom .stopwatch-paused, .panel-bottom .stopwatch-ready:hover, .panel-bottom .stopwatch-paused:hover {
   border-bottom: 1px;
   padding-top: 1px;
 }
 
-.panel-top .stopwatch-running, .panel-top
-.stopwatch-paused, .panel-top
-.stopwatch-ready:hover, .panel-top
-.stopwatch-paused:hover {
+.panel-top .stopwatch-running, .panel-top .stopwatch-paused, .panel-top .stopwatch-ready:hover, .panel-top .stopwatch-paused:hover {
   border-top: 1px;
   padding-bottom: 1px;
 }
@@ -2986,11 +2988,20 @@ StEntry:pressed > StIcon,
   padding: 6px;
 }
 
+.starkmenu-background .menu-favorites-box .menu-favorites-button :first-child {
+  padding-right: 6px;
+}
+
 .starkmenu-background .menu-favorites-box .menu-context-menu {
   border-radius: 3px;
   color: rgba(255, 255, 255, 0.95);
   border: 1px solid rgba(0, 0, 0, 0.35);
   background-color: #090909;
+}
+
+.starkmenu-background .menu-favorites-box .menu-category-button :last-child,
+.starkmenu-background .menu-favorites-box .menu-category-button-selected :last-child {
+  padding-top: 2px;
 }
 
 .starkmenu-background .right-buttons-box {

--- a/Adara/cinnamon/cinnamon.css
+++ b/Adara/cinnamon/cinnamon.css
@@ -149,9 +149,7 @@ StEntry StIcon,
   icon-size: 16px;
 }
 
-StEntry:focus > StIcon,
-StEntry:active > StIcon,
-StEntry:pressed > StIcon,
+StEntry:focus > StIcon, StEntry:active > StIcon, StEntry:pressed > StIcon,
 .menu StEntry:focus > StIcon,
 .menu StEntry:active > StIcon,
 .menu StEntry:pressed > StIcon,
@@ -958,6 +956,12 @@ StEntry:pressed > StIcon,
  * ! Grouped window list
  * ====================================== */
 .grouped-window-list-thumbnail-menu {
+  border-radius: 3px;
+  color: rgba(0, 0, 0, 0.7);
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  background-color: #fafafa;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+  padding: 3px;
   spacing: 3px;
 }
 
@@ -992,7 +996,7 @@ StEntry:pressed > StIcon,
 }
 
 .grouped-window-list-button-label {
-  padding: 0;
+  padding: 0 6px;
 }
 
 .grouped-window-list-item-box {
@@ -2026,12 +2030,12 @@ StEntry:pressed > StIcon,
  *
  * See also window-list module for a similar selector
  */
-#uiGroup > #altTabPopup {
+#altTabPopup {
   padding: 0;
   spacing: 6px;
 }
 
-#uiGroup > #altTabPopup .switcher-list {
+#altTabPopup .switcher-list {
   border-radius: 3px;
   color: rgba(0, 0, 0, 0.7);
   border: 1px solid rgba(0, 0, 0, 0.2);
@@ -2042,28 +2046,34 @@ StEntry:pressed > StIcon,
   padding: 3px;
 }
 
-#uiGroup > #altTabPopup .switcher-list .item-box {
+#altTabPopup .switcher-list .item-box {
   padding: 6px;
 }
 
-#uiGroup > #altTabPopup .switcher-list .item-box:selected {
+#altTabPopup .switcher-list .item-box:selected {
   background-color: rgba(0, 0, 0, 0.15);
   border-radius: 3px;
   color: rgba(0, 0, 0, 0.7);
-  /* Popup thumbnail */
+  /*
+				 *  Popup thumbnail
+				 *      Commented this out because it also affects the last item in the window selection,
+				 *      not showing it as highlighted. The popup thumbnails are currently darkened
+				 *      like the selected item in the window selection, this should probably be fixed
+				 */
+  /*
+				&:last-child {
+					padding: $padding-xs;
+					background: none;
+					color: $text-primary;
+				}
+				*/
 }
 
-#uiGroup > #altTabPopup .switcher-list .item-box:selected:last-child {
-  padding: 6px;
-  background: none;
-  color: rgba(0, 0, 0, 0.7);
-}
-
-#uiGroup > #altTabPopup .switcher-arrow {
+#altTabPopup .switcher-arrow {
   color: transparent;
 }
 
-#uiGroup > #altTabPopup .thumbnail {
+#altTabPopup .thumbnail {
   width: 256px;
 }
 
@@ -2071,7 +2081,7 @@ StEntry:pressed > StIcon,
  * This styles the window name box when alt-tab is
  * in 'coverflow' or 'timeline' modes
  */
-#uiGroup > StWidget > .switcher-list {
+StWidget > .switcher-list {
   border-radius: 3px;
   color: rgba(0, 0, 0, 0.7);
   border: 1px solid rgba(0, 0, 0, 0.2);
@@ -2412,9 +2422,7 @@ StEntry:pressed > StIcon,
   icon-size: 16px;
 }
 
-.menu .slingshot .entry:focus > StIcon,
-.menu .slingshot .entry:active > StIcon,
-.menu .slingshot .entry:pressed > StIcon {
+.menu .slingshot .entry:focus > StIcon, .menu .slingshot .entry:active > StIcon, .menu .slingshot .entry:pressed > StIcon {
   color: rgba(0, 0, 0, 0.7);
 }
 
@@ -2786,18 +2794,12 @@ StEntry:pressed > StIcon,
   font-size: 100%;
 }
 
-.panel-bottom .stopwatch-running, .panel-bottom
-.stopwatch-paused, .panel-bottom
-.stopwatch-ready:hover, .panel-bottom
-.stopwatch-paused:hover {
+.panel-bottom .stopwatch-running, .panel-bottom .stopwatch-paused, .panel-bottom .stopwatch-ready:hover, .panel-bottom .stopwatch-paused:hover {
   border-bottom: 1px;
   padding-top: 1px;
 }
 
-.panel-top .stopwatch-running, .panel-top
-.stopwatch-paused, .panel-top
-.stopwatch-ready:hover, .panel-top
-.stopwatch-paused:hover {
+.panel-top .stopwatch-running, .panel-top .stopwatch-paused, .panel-top .stopwatch-ready:hover, .panel-top .stopwatch-paused:hover {
   border-top: 1px;
   padding-bottom: 1px;
 }
@@ -2986,11 +2988,20 @@ StEntry:pressed > StIcon,
   padding: 6px;
 }
 
+.starkmenu-background .menu-favorites-box .menu-favorites-button :first-child {
+  padding-right: 6px;
+}
+
 .starkmenu-background .menu-favorites-box .menu-context-menu {
   border-radius: 3px;
   color: rgba(0, 0, 0, 0.7);
   border: 1px solid rgba(0, 0, 0, 0.15);
   background-color: #f0f0f0;
+}
+
+.starkmenu-background .menu-favorites-box .menu-category-button :last-child,
+.starkmenu-background .menu-favorites-box .menu-category-button-selected :last-child {
+  padding-top: 2px;
 }
 
 .starkmenu-background .right-buttons-box {

--- a/Adara/cinnamon/scss/base/_options.scss
+++ b/Adara/cinnamon/scss/base/_options.scss
@@ -1,1 +1,1 @@
-$dark-mode: false;
+$dark-mode: true;

--- a/Adara/cinnamon/scss/main/_alt-tab.scss
+++ b/Adara/cinnamon/scss/main/_alt-tab.scss
@@ -6,7 +6,7 @@
  *
  * See also window-list module for a similar selector
  */
-#uiGroup > #altTabPopup {
+#altTabPopup {
 	padding: 0;
 	spacing: $padding-xs;
 
@@ -23,12 +23,20 @@
 				@include hover;
 				color: $text-primary;
 
-				/* Popup thumbnail */
+				/*
+				 *  Popup thumbnail
+				 *      Commented this out because it also affects the last item in the window selection,
+				 *      not showing it as highlighted. The popup thumbnails are currently darkened
+				 *      like the selected item in the window selection, this should probably be fixed
+				 */
+
+				/*
 				&:last-child {
 					padding: $padding-xs;
 					background: none;
 					color: $text-primary;
 				}
+				*/
 			}
 		}
 	}
@@ -45,7 +53,7 @@
  * This styles the window name box when alt-tab is
  * in 'coverflow' or 'timeline' modes
  */
-#uiGroup > StWidget > .switcher-list {
+StWidget > .switcher-list {
 	@include background-element;
 	font-weight: normal;
 }

--- a/Adara/cinnamon/scss/main/applets/_window-list.scss
+++ b/Adara/cinnamon/scss/main/applets/_window-list.scss
@@ -64,6 +64,8 @@
 
 .grouped-window-list {
 	&-thumbnail-menu {
+		@include background-element; // Transparent thumbnail menu fix
+		padding: $padding-xxs;
 		spacing: $padding-xxs;
 
 		.item-box {
@@ -95,7 +97,7 @@
 	}
 
 	&-button-label {
-		padding: 0; // Reset this
+		padding: 0 $padding-xs; // Fix missing spacing between icon and label
 	}
 
 	&-item-box {

--- a/Adara/cinnamon/scss/third-party__applets/_stark-menu.scss
+++ b/Adara/cinnamon/scss/third-party__applets/_stark-menu.scss
@@ -36,11 +36,24 @@
 
 		.menu-favorites-button {
 			padding: $padding-xs;
+
+			// Fix missing spacing between favorite icons and label
+			:first-child {
+			    padding-right: $padding-xs;
+			}
 		}
 
 		.menu-context-menu {
 			@include background-element(secondary);
 		}
+
+		// Vertically align the "All Programs" text with the icon
+		.menu-category-button,
+	    .menu-category-button-selected {
+            :last-child {
+                padding-top: $padding-xxs - 1;
+            }
+        }
 	}
 
 	.right-buttons-box {


### PR DESCRIPTION
Fixed some things that broke over the years, namely:
- Some selectors going through `#uiGroup` no longer working 
- Last item in the alt-tab window selection is not properly shown as highlighted;
- Grouped window list thumbnail menu not having a background;
- Missing spacing between grouped window list icons and labels;
- Missing spacing between StarkMenu favorite app icons and labels;
- Vertically misaligned "All Programs" label in StarkMenu