### PR TITLE
Blurry checkboxes fix

### DIFF
--- a/Adara-Dark/cinnamon/cinnamon.css
+++ b/Adara-Dark/cinnamon/cinnamon.css
@@ -149,9 +149,7 @@ StEntry StIcon,
   icon-size: 16px;
 }
 
-StEntry:focus > StIcon,
-StEntry:active > StIcon,
-StEntry:pressed > StIcon,
+StEntry:focus > StIcon, StEntry:active > StIcon, StEntry:pressed > StIcon,
 .menu StEntry:focus > StIcon,
 .menu StEntry:active > StIcon,
 .menu StEntry:pressed > StIcon,
@@ -186,12 +184,12 @@ StEntry:pressed > StIcon,
  * ====================================== */
 .check-box CinnamonGenericContainer {
   spacing: .2em;
-  min-height: 17px;
+  min-height: 16px;
 }
 
 .check-box StBin {
-  width: 17px;
-  height: 17px;
+  width: 16px;
+  height: 16px;
   background-image: url("img/controls/check-box.svg");
 }
 
@@ -209,12 +207,12 @@ StEntry:pressed > StIcon,
 
 .radiobutton CinnamonGenericContainer {
   spacing: .2em;
-  min-height: 17px;
+  min-height: 16px;
 }
 
 .radiobutton StBin {
-  width: 17px;
-  height: 17px;
+  width: 16px;
+  height: 16px;
   background-image: url("img/controls/radiobutton.svg");
 }
 
@@ -2412,9 +2410,7 @@ StEntry:pressed > StIcon,
   icon-size: 16px;
 }
 
-.menu .slingshot .entry:focus > StIcon,
-.menu .slingshot .entry:active > StIcon,
-.menu .slingshot .entry:pressed > StIcon {
+.menu .slingshot .entry:focus > StIcon, .menu .slingshot .entry:active > StIcon, .menu .slingshot .entry:pressed > StIcon {
   color: rgba(255, 255, 255, 0.95);
 }
 
@@ -2786,18 +2782,12 @@ StEntry:pressed > StIcon,
   font-size: 100%;
 }
 
-.panel-bottom .stopwatch-running, .panel-bottom
-.stopwatch-paused, .panel-bottom
-.stopwatch-ready:hover, .panel-bottom
-.stopwatch-paused:hover {
+.panel-bottom .stopwatch-running, .panel-bottom .stopwatch-paused, .panel-bottom .stopwatch-ready:hover, .panel-bottom .stopwatch-paused:hover {
   border-bottom: 1px;
   padding-top: 1px;
 }
 
-.panel-top .stopwatch-running, .panel-top
-.stopwatch-paused, .panel-top
-.stopwatch-ready:hover, .panel-top
-.stopwatch-paused:hover {
+.panel-top .stopwatch-running, .panel-top .stopwatch-paused, .panel-top .stopwatch-ready:hover, .panel-top .stopwatch-paused:hover {
   border-top: 1px;
   padding-bottom: 1px;
 }

--- a/Adara/cinnamon/cinnamon.css
+++ b/Adara/cinnamon/cinnamon.css
@@ -149,9 +149,7 @@ StEntry StIcon,
   icon-size: 16px;
 }
 
-StEntry:focus > StIcon,
-StEntry:active > StIcon,
-StEntry:pressed > StIcon,
+StEntry:focus > StIcon, StEntry:active > StIcon, StEntry:pressed > StIcon,
 .menu StEntry:focus > StIcon,
 .menu StEntry:active > StIcon,
 .menu StEntry:pressed > StIcon,
@@ -186,12 +184,12 @@ StEntry:pressed > StIcon,
  * ====================================== */
 .check-box CinnamonGenericContainer {
   spacing: .2em;
-  min-height: 17px;
+  min-height: 16px;
 }
 
 .check-box StBin {
-  width: 17px;
-  height: 17px;
+  width: 16px;
+  height: 16px;
   background-image: url("img/controls/check-box.svg");
 }
 
@@ -209,12 +207,12 @@ StEntry:pressed > StIcon,
 
 .radiobutton CinnamonGenericContainer {
   spacing: .2em;
-  min-height: 17px;
+  min-height: 16px;
 }
 
 .radiobutton StBin {
-  width: 17px;
-  height: 17px;
+  width: 16px;
+  height: 16px;
   background-image: url("img/controls/radiobutton.svg");
 }
 
@@ -2412,9 +2410,7 @@ StEntry:pressed > StIcon,
   icon-size: 16px;
 }
 
-.menu .slingshot .entry:focus > StIcon,
-.menu .slingshot .entry:active > StIcon,
-.menu .slingshot .entry:pressed > StIcon {
+.menu .slingshot .entry:focus > StIcon, .menu .slingshot .entry:active > StIcon, .menu .slingshot .entry:pressed > StIcon {
   color: rgba(0, 0, 0, 0.7);
 }
 
@@ -2786,18 +2782,12 @@ StEntry:pressed > StIcon,
   font-size: 100%;
 }
 
-.panel-bottom .stopwatch-running, .panel-bottom
-.stopwatch-paused, .panel-bottom
-.stopwatch-ready:hover, .panel-bottom
-.stopwatch-paused:hover {
+.panel-bottom .stopwatch-running, .panel-bottom .stopwatch-paused, .panel-bottom .stopwatch-ready:hover, .panel-bottom .stopwatch-paused:hover {
   border-bottom: 1px;
   padding-top: 1px;
 }
 
-.panel-top .stopwatch-running, .panel-top
-.stopwatch-paused, .panel-top
-.stopwatch-ready:hover, .panel-top
-.stopwatch-paused:hover {
+.panel-top .stopwatch-running, .panel-top .stopwatch-paused, .panel-top .stopwatch-ready:hover, .panel-top .stopwatch-paused:hover {
   border-top: 1px;
   padding-bottom: 1px;
 }

--- a/Adara/cinnamon/img/controls/radiobutton-checked-focused.svg
+++ b/Adara/cinnamon/img/controls/radiobutton-checked-focused.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg width="17" height="17" enable-background="new" version="1.0" xmlns="http://www.w3.org/2000/svg">
- <circle cx="8.5" cy="8.5" r="8" color="#000000" color-rendering="auto" enable-background="accumulate" fill="none" image-rendering="auto" shape-rendering="auto" solid-color="#000000" stroke="#599be7" style="isolation:auto;mix-blend-mode:normal"/>
- <circle cx="8.5" cy="8.5" r="7.5" color="#000000" color-rendering="auto" enable-background="accumulate" fill="#fff" image-rendering="auto" shape-rendering="auto" solid-color="#000000" style="isolation:auto;mix-blend-mode:normal"/>
- <circle cx="8.5" cy="8.5" r="4" color="#000000" color-rendering="auto" enable-background="accumulate" image-rendering="auto" opacity=".75" shape-rendering="auto" solid-color="#000000" style="isolation:auto;mix-blend-mode:normal"/>
+<svg width="16" height="16" enable-background="new" version="1.0" xmlns="http://www.w3.org/2000/svg">
+ <circle cx="8" cy="8" r="7.5" color="#000000" color-rendering="auto" enable-background="accumulate" fill="none" image-rendering="auto" shape-rendering="auto" solid-color="#000000" stroke="#599be7" style="isolation:auto;mix-blend-mode:normal"/>
+ <circle cx="8" cy="8" r="7.0312" color="#000000" color-rendering="auto" enable-background="accumulate" fill="#ffffff" image-rendering="auto" shape-rendering="auto" solid-color="#000000" style="isolation:auto;mix-blend-mode:normal"/>
+ <circle cx="8" cy="8" r="3.75" color="#000000" color-rendering="auto" enable-background="accumulate" image-rendering="auto" opacity=".75" shape-rendering="auto" solid-color="#000000" style="isolation:auto;mix-blend-mode:normal"/>
 </svg>

--- a/Adara/cinnamon/img/controls/radiobutton-checked.svg
+++ b/Adara/cinnamon/img/controls/radiobutton-checked.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg width="17" height="17" enable-background="new" version="1.0" xmlns="http://www.w3.org/2000/svg">
- <circle cx="8.5" cy="8.5" r="8" color="#000000" color-rendering="auto" enable-background="accumulate" fill="none" image-rendering="auto" opacity=".2" shape-rendering="auto" solid-color="#000000" stroke="#000" style="isolation:auto;mix-blend-mode:normal"/>
- <circle cx="8.5" cy="8.5" r="7.5" color="#000000" color-rendering="auto" enable-background="accumulate" fill="#fff" image-rendering="auto" shape-rendering="auto" solid-color="#000000" style="isolation:auto;mix-blend-mode:normal"/>
- <circle cx="8.5" cy="8.5" r="4" color="#000000" color-rendering="auto" enable-background="accumulate" image-rendering="auto" opacity=".75" shape-rendering="auto" solid-color="#000000" style="isolation:auto;mix-blend-mode:normal"/>
+<svg width="16" height="16" enable-background="new" version="1.0" xmlns="http://www.w3.org/2000/svg">
+ <circle cx="8" cy="8" r="7.5" color="#000000" color-rendering="auto" enable-background="accumulate" fill="none" image-rendering="auto" opacity=".2" shape-rendering="auto" solid-color="#000000" stroke="#000000" style="isolation:auto;mix-blend-mode:normal"/>
+ <circle cx="8" cy="8" r="7.0312" color="#000000" color-rendering="auto" enable-background="accumulate" fill="#ffffff" image-rendering="auto" shape-rendering="auto" solid-color="#000000" style="isolation:auto;mix-blend-mode:normal"/>
+ <circle cx="8" cy="8" r="3.75" color="#000000" color-rendering="auto" enable-background="accumulate" image-rendering="auto" opacity=".75" shape-rendering="auto" solid-color="#000000" style="isolation:auto;mix-blend-mode:normal"/>
 </svg>

--- a/Adara/cinnamon/img/controls/radiobutton-focused.svg
+++ b/Adara/cinnamon/img/controls/radiobutton-focused.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg width="17" height="17" enable-background="new" version="1.0" xmlns="http://www.w3.org/2000/svg">
- <circle cx="8.5" cy="8.5" r="8" color="#000000" color-rendering="auto" enable-background="accumulate" fill="none" image-rendering="auto" shape-rendering="auto" solid-color="#000000" stroke="#599be7" style="isolation:auto;mix-blend-mode:normal"/>
- <circle cx="8.5" cy="8.5" r="7.5" color="#000000" color-rendering="auto" enable-background="accumulate" fill="#fff" image-rendering="auto" shape-rendering="auto" solid-color="#000000" style="isolation:auto;mix-blend-mode:normal"/>
+<svg width="16" height="16" enable-background="new" version="1.0" xmlns="http://www.w3.org/2000/svg">
+ <circle cx="8" cy="8" r="7.5" color="#000000" color-rendering="auto" enable-background="accumulate" fill="none" image-rendering="auto" shape-rendering="auto" solid-color="#000000" stroke="#599be7" style="isolation:auto;mix-blend-mode:normal"/>
+ <circle cx="8" cy="8" r="7.0312" color="#000000" color-rendering="auto" enable-background="accumulate" fill="#ffffff" image-rendering="auto" shape-rendering="auto" solid-color="#000000" style="isolation:auto;mix-blend-mode:normal"/>
 </svg>

--- a/Adara/cinnamon/img/controls/radiobutton.svg
+++ b/Adara/cinnamon/img/controls/radiobutton.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg width="17" height="17" enable-background="new" version="1.0" xmlns="http://www.w3.org/2000/svg">
- <circle cx="8.5" cy="8.5" r="8" color="#000000" color-rendering="auto" enable-background="accumulate" fill="none" image-rendering="auto" opacity=".2" shape-rendering="auto" solid-color="#000000" stroke="#000" style="isolation:auto;mix-blend-mode:normal"/>
- <circle cx="8.5" cy="8.5" r="7.5" color="#000000" color-rendering="auto" enable-background="accumulate" fill="#fff" image-rendering="auto" shape-rendering="auto" solid-color="#000000" style="isolation:auto;mix-blend-mode:normal"/>
+<svg width="16" height="16" enable-background="new" version="1.0" xmlns="http://www.w3.org/2000/svg">
+ <circle cx="8" cy="8" r="7.5" color="#000000" color-rendering="auto" enable-background="accumulate" fill="none" image-rendering="auto" opacity=".2" shape-rendering="auto" solid-color="#000000" stroke="#000000" style="isolation:auto;mix-blend-mode:normal"/>
+ <circle cx="8" cy="8" r="7.0312" color="#000000" color-rendering="auto" enable-background="accumulate" fill="#ffffff" image-rendering="auto" shape-rendering="auto" solid-color="#000000" style="isolation:auto;mix-blend-mode:normal"/>
 </svg>

--- a/Adara/cinnamon/scss/main/controls/_checkboxes-&-radiobuttons.scss
+++ b/Adara/cinnamon/scss/main/controls/_checkboxes-&-radiobuttons.scss
@@ -6,12 +6,12 @@
 	.#{$v} {
 		CinnamonGenericContainer {
 			spacing: .2em;
-			min-height: 17px;
+			min-height: 16px;
 		}
 
 		StBin {
-			width: 17px;
-			height: 17px;
+			width: 16px;
+			height: 16px;
 			background-image: url("img/controls/#{$v}.svg");
 		}
 


### PR DESCRIPTION
The "Always on Top" checkbox in the window menu looks blurry because its assets are 16x16px instead of 17x17px like the radio button's, which are displayed properly.
![cboxsize-og](https://github.com/user-attachments/assets/01f6d1e2-ee5a-4cd0-97ad-1517eed8839d)

This fix normalizes the size of those assets to 16x16 for consistency across the two controls, and to remove the blur from the checkbox.
![cboxsize-fix](https://github.com/user-attachments/assets/02aa70f8-3719-458e-889f-f578ca95a761)
